### PR TITLE
Add reusable section component

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,5 +1,4 @@
 import "./src/styles/global.css";
 import wrapWithProvider from "./wrap-with-provider"
 
-document.title = "Vaughn Johnson";
 export const wrapRootElement = wrapWithProvider

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  siteMetadata: {
+    title: `Vaughn Johnson`
+  },
+  plugins: [
+    {
+      resolve: `gatsby-plugin-google-fonts`,
+      options: {
+        fonts: [
+          `poppins`,
+          `crimson text`
+        ],
+        display: 'swap'
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@material-ui/core": "^4.11.0",
     "clsx": "^1.1.1",
     "gatsby": "^2.25.1",
+    "gatsby-plugin-google-fonts": "^1.0.1",
     "react": "^16.12.0",
     "react-dom": "^17.0.1",
     "react-icons": "^3.11.0",

--- a/src/components/Section/Section.js
+++ b/src/components/Section/Section.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Title from './Title';
 import * as styles from './styles';
+import PropTypes from "prop-types";
 
 const Section = ({title, subtitle, children}) => (
   <div style={{ display: 'flex', justifyContent: 'space-around' }}>
@@ -10,5 +11,12 @@ const Section = ({title, subtitle, children}) => (
     </div>
   </div>
 );
+
+Section.propTypes = {
+  title: PropTypes.string.isRequired,
+  subtitle: PropTypes.string.isRequired,
+  children: PropTypes.element
+};
+
 
 export default Section;

--- a/src/components/Section/Section.js
+++ b/src/components/Section/Section.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import Title from './Title';
+import * as styles from './styles';
+
+const Section = ({title, subtitle, children}) => (
+  <div style={{ display: 'flex', justifyContent: 'space-around' }}>
+    <div style={styles.section}>
+      <Title title={title} subtitle={subtitle} />
+      {children}
+    </div>
+  </div>
+);
+
+export default Section;

--- a/src/components/Section/Title.js
+++ b/src/components/Section/Title.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import * as styles from './styles';
+
+const Title = ({ title, subtitle }) => (
+  <div>
+    <p style={styles.title}>{title}</p>
+    <p style={styles.subTitle}>{subtitle}</p>
+  </div>
+);
+
+export default Title;

--- a/src/components/Section/Title.js
+++ b/src/components/Section/Title.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import * as styles from './styles';
+import PropTypes from "prop-types";
 
 const Title = ({ title, subtitle }) => (
   <div>
@@ -7,5 +8,11 @@ const Title = ({ title, subtitle }) => (
     <p style={styles.subTitle}>{subtitle}</p>
   </div>
 );
+
+Title.propTypes = {
+  title: PropTypes.string.isRequired,
+  subtitle: PropTypes.string.isRequired,
+  children: PropTypes.element
+};
 
 export default Title;

--- a/src/components/Section/index.js
+++ b/src/components/Section/index.js
@@ -1,0 +1,3 @@
+import Section from './Section';
+
+export default Section;

--- a/src/components/Section/styles.js
+++ b/src/components/Section/styles.js
@@ -1,0 +1,43 @@
+import Null from 'components/NullComponent';
+import { colors } from 'styles';
+
+const title = {
+  fontFamily: 'Poppins',
+  fontSize: 'calc(1.5em + 2vw)',
+  fontWeight: 600,
+  color: 'black',
+  textIndent: 0,
+  marginBottom: '2vw',
+  hyphens: 'auto',
+  WebkitHyphens: 'auto'
+}
+
+const subTitle = {
+  fontFamily: 'Poppins',
+  fontSize: 'calc(1.2em + 0.5vw)',
+  fontWeight: 400,
+  color: colors.grey,
+  textIndent: 0,
+  marginTop: 0,
+  hyphen: 'auto',
+  WebkitHyphens: 'auto'
+}
+
+const section = {
+  maxWidth: '750px', 
+  paddingLeft: '3vw',
+  paddingRight: '3vw',
+  fontFamily: 'Crimson Text',
+  fontSize: 'calc(1.1em + 0.5vw)',
+  textIndent: '3vw'
+}
+
+export {
+  title,
+  subTitle,
+  section
+}
+
+// Gatsby requires a default export
+// to be a component or string
+export default Null;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,9 +1,13 @@
 import Button from './Button';
 import Header from './Header';
+import TitleCard from './TitleCard';
+import Section from './Section';
 import NullComponent from './NullComponent';
 
 export {
   Button,
   Header,
+  TitleCard,
+  Section,
   NullComponent
 };

--- a/src/styles/colors.js
+++ b/src/styles/colors.js
@@ -2,7 +2,8 @@ const colors = {
   pink: '#E83385',
   orange: '#FF9E33',
   purple: '#65219D',
-  yellow: '#fade0f'
+  yellow: '#fade0f',
+  grey: '#999999'
 };
 
 export default colors;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
-
 body { 
   margin: 0;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5895,6 +5895,11 @@ gatsby-page-utils@^0.2.29:
     lodash "^4.17.20"
     micromatch "^4.0.2"
 
+gatsby-plugin-google-fonts@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-google-fonts/-/gatsby-plugin-google-fonts-1.0.1.tgz#d71054f7bf207b9a8da227380369e18e6f4e0201"
+  integrity sha512-p1NVkn27GUnDA5qHM+Z4cCcLCJIardzZXMon3640sT4xuL/AZJbsx3HEt2KY/5oZu0UXIkytkxzV2Da4rQeUIg==
+
 gatsby-plugin-page-creator@^2.3.34:
   version "2.3.34"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.3.34.tgz#4b76a63e3c68d0b8b4901cd778dff37d29f3813b"


### PR DESCRIPTION
To test, I replaced `pages/index.js` with

```{javascript}

import React from 'react';
import { TitleCard, Header, Section } from 'components';

export default () => (
  <div>
    <Header />
    <TitleCard image='assets/images/selfie.jpg'>Mining my own therapy data</TitleCard>
    <Section
      title='Introduction'
      subtitle='What am I trying to understand?'
    >
      <p>
        Talkspace is an online, text-based therapy service.
        I have been using the service for about a year, and over that time, I've noticed it's sometimes hard for me to stay engaged.
        There have been long stretches of times where I have not responded to my therapist.
        Patient engagement is critical to developing a therapeutic relationship, so if I can increase my own responsiveness,
        I might increase the efficacy of my therapy.
      </p>
      <img style={{ width: '100%' }} src='assets/images/selfie.jpg' />
    </Section>
  </div>
);
```

![Screen Shot 2020-11-16 at 3 59 50 PM](https://user-images.githubusercontent.com/73358021/99322450-d147a800-2824-11eb-9241-12992f957cf2.png)


<img width="780" alt="Screen Shot 2020-11-16 at 3 53 13 PM" src="https://user-images.githubusercontent.com/73358021/99322358-a0677300-2824-11eb-8394-fcfe5d52c43f.png">
<img width="456" alt="Screen Shot 2020-11-16 at 3 53 09 PM" src="https://user-images.githubusercontent.com/73358021/99322367-a4939080-2824-11eb-9f90-a6ce41b70bbc.png">

![Screen Shot 2020-11-16 at 3 59 39 PM](https://user-images.githubusercontent.com/73358021/99322436-cb51c700-2824-11eb-86f9-946e71b17d41.png)

