### PR TITLE
Moved meta title back to gatsby-browser.js

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,4 +1,5 @@
 import "./src/styles/global.css";
 import wrapWithProvider from "./wrap-with-provider"
 
+document.title = `Vaughn Johnson`
 export const wrapRootElement = wrapWithProvider

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,7 +1,4 @@
 module.exports = {
-  siteMetadata: {
-    title: `Vaughn Johnson`
-  },
   plugins: [
     {
       resolve: `gatsby-plugin-google-fonts`,


### PR DESCRIPTION
<img width="284" alt="Screen Shot 2020-11-17 at 2 05 30 PM" src="https://user-images.githubusercontent.com/73358021/99456383-2b587400-28de-11eb-8d08-588aa7065f50.png">
![Uploading Screen Shot 2020-11-17 at 2.06.21 PM.png…]()
